### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: Python Lint
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   ruff:


### PR DESCRIPTION
Potential fix for [https://github.com/Adam3Haikal3/UCP-Capstone/security/code-scanning/1](https://github.com/Adam3Haikal3/UCP-Capstone/security/code-scanning/1)

To fix the problem, explicitly declare least-privilege permissions for the workflow so the `GITHUB_TOKEN` has only the access required. For this linting workflow, read-only access to repository contents is sufficient.

The best fix without changing functionality is to add a top-level `permissions:` block (applies to all jobs) specifying `contents: read`. Insert it after the `on:` declaration near the top of `.github/workflows/lint.yml`. No additional methods, imports, or definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
